### PR TITLE
Modify the weblog example template to comply with Apache access_combined format

### DIFF
--- a/examples/common/weblog.yml
+++ b/examples/common/weblog.yml
@@ -64,4 +64,4 @@ lines:
     sourcetype: access_combined
     source: /var/log/httpd/access_log
     host: $host$
-    _raw: $ip$ $clientip$ - - [$ts$] "GET /product.screen?product_id=HolyGouda&JSESSIONID=SD3SL1FF7ADFF8 HTTP 1.1" $status$ $timetaken$ "http://shop.buttercupgames.com/cart.do?action=view&itemId=HolyGouda" "$useragent$" $size$
+    _raw: $clientip$ - - [$ts$] "GET /product.screen?product_id=HolyGouda&JSESSIONID=SD3SL1FF7ADFF8 HTTP 1.1" $status$ $size$ "http://shop.buttercupgames.com/cart.do?action=view&itemId=HolyGouda" "$useragent$"

--- a/examples/common/weblog.yml
+++ b/examples/common/weblog.yml
@@ -13,7 +13,7 @@ tokens:
     format: template
     token: $ts$
     type: gotimestamp
-    replacement: "02/Jan/2006 15:04:05"
+    replacement: "02/Jan/2006:15:04:05 +0000"
   - name: host
     format: template
     type: fieldChoice

--- a/examples/common/weblog.yml
+++ b/examples/common/weblog.yml
@@ -21,12 +21,6 @@ tokens:
     field: host
     sample: webhosts.csv
     group: 1
-  - name: ip
-    format: template
-    type: fieldChoice
-    srcField: ip
-    sample: webhosts.csv
-    group: 1
   - name: clientip
     format: template
     type: choice
@@ -43,12 +37,6 @@ tokens:
       choice: 404
     - weight: 2
       choice: 503
-  - name: timetaken
-    format: template
-    type: random
-    replacement: int
-    lower: 100
-    upper: 1000
   - name: useragent
     format: template
     type: choice


### PR DESCRIPTION
Weblogs generated by this template weren't recognized by Splunk's access_combined sourcetype and don't match up with the access_common or access_combined formats as specified [by Apache docs](https://httpd.apache.org/docs/2.4/logs.html). I've brought them into line with the spec.