### PR TITLE
Add support for network (tcp/udp) outputter

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -62,6 +62,9 @@ type Output struct {
 	OutputTemplate string            `json:"outputTemplate,omitempty" yaml:"outputTemplate,omitempty"`
 	Endpoints      []string          `json:"endpoints,omitempty" yaml:"endpoints,omitempty"`
 	Headers        map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Protocol       string            `json:"protocol,omitempty" yaml:"protocol,omitempty"`
+	Server         string            `json:"server,omitempty" yaml:"server,omitempty"`
+	NetworkTimeout string            `json:"networkTimeout,omitempty" yaml:"networkTimeout,omitempty"`
 }
 
 // ConfigConfig represents options to pass to NewConfig

--- a/outputter/network.go
+++ b/outputter/network.go
@@ -1,0 +1,41 @@
+package outputter
+
+import (
+	"io"
+	"net"
+	"time"
+
+	config "github.com/coccyx/gogen/internal"
+)
+
+type network struct {
+	conn        net.Conn
+	initialized bool
+	closed      bool
+}
+
+func (n *network) Send(item *config.OutQueueItem) error {
+	if n.initialized == false {
+		timeout, err := time.ParseDuration(item.S.Output.NetworkTimeout)
+		if err != nil {
+			timeout, _ = time.ParseDuration("10s")
+		}
+
+		conn, err := net.DialTimeout(item.S.Output.Protocol, item.S.Output.Server, timeout)
+		if err != nil {
+			return err
+		}
+		n.conn = conn
+		n.initialized = true
+	}
+	_, err := io.Copy(n.conn, item.IO.R)
+	return err
+}
+
+func (n *network) Close() error {
+	n.closed = true
+	if n.conn != nil {
+		return n.conn.Close()
+	}
+	return nil
+}

--- a/outputter/outputter.go
+++ b/outputter/outputter.go
@@ -197,6 +197,8 @@ func setup(generator *rand.Rand, item *config.OutQueueItem, num int) config.Outp
 			gout[num] = new(buf)
 		case "splunktcp":
 			gout[num] = new(splunktcp)
+		case "network":
+			gout[num] = new(network)
 		default:
 			gout[num] = new(stdout)
 		}


### PR DESCRIPTION
Added basic support for outputting to UDP or TCP network connections.

A modified weblog.yml example testing this functionality looks like:

```
global:
  samplesDir: 
  - $GOGEN_HOME/examples/common
  output:
    protocol: tcp
    server: 192.168.1.10:10000
    networkTimeout: 5s
    outputter: network
samples:
  - name: weblog
    fromSample: weblog-common
    interval: 1
    endIntervals: 1
    count: 10
```