### PR TITLE
Fix errors in tutorial

### DIFF
--- a/README/Tutorial.md
+++ b/README/Tutorial.md
@@ -1,6 +1,6 @@
 # Configuring Gogen
 
-Gogen is the spiritual successor to my original [Eventgen](https://github.com/splunk/eventgen), and as such it shares many configuration concepts in common.  However, Gogen as the successor has been designed to work around a number of deficiencies in Eventgen's original configuration format.  
+Gogen is the spiritual successor to my original [Eventgen](https://github.com/splunk/eventgen), and as such it shares many configuration concepts in common.  However, Gogen as the successor has been designed to work around a number of deficiencies in Eventgen's original configuration format.
 
 Gogen was designed to be configured from a single file.  This makes moving configurations around very simple.  Managing the data Gogen references is painful from a single file, so it also allows for referencing other files.  For example, choice token types allow choosing items from fields in other samples, and these samples can be referenced to files on the file system.  When publishing the configurations, Gogen will take it's in-memory representation which has joined all the configuration data together, and generate a single file version of this configuration.  Later, if desired, Gogen can deconstruct this single file representation back into component files to make editing easier.
 
@@ -14,7 +14,7 @@ Gogen is configured via a YAML or JSON based configuration.  Lets look at a very
         endIntervals: 5
         count: 1
         randomizeEvents: true
-        
+
         tokens:
         - name: ts
           format: template
@@ -26,7 +26,7 @@ Gogen is configured via a YAML or JSON based configuration.  Lets look at a very
         - _raw: $ts$ line2
         - _raw: $ts$ line3
 
-This example is in YAML.  Gogen configurations are made up of Samples, which contain some configuration, tokens, and lines.  In this example, we will generate 1 event (`count: 1`) from a random line (`randomizeEvents: true`) every 1 second (`interval: 1`) for a total of 5 intervals (`endIntervals 5`).  When `endIntervals` is set, we will go back that number of intervals and just work as fast as we can to generate that number of events.  Gogen can also keep generating and generate in realtime, which we'll cover a bit later.  
+This example is in YAML.  Gogen configurations are made up of Samples, which contain some configuration, tokens, and lines.  In this example, we will generate 1 event (`count: 1`) from a random line (`randomizeEvents: true`) every 1 second (`interval: 1`) for a total of 5 intervals (`endIntervals 5`).  When `endIntervals` is set, we will go back that number of intervals and just work as fast as we can to generate that number of events.  Gogen can also keep generating and generate in realtime, which we'll cover a bit later.
 
 You can see we define here a top level item called samples, which is a list of objects.  There are a few top level directives which control Gogen:
 
@@ -47,7 +47,7 @@ To run this example, from the Gogen repo directory:
 
 ## Raters & Scripts
 
-Two of the most important concepts in Gogen are the concepts of rater and scripts.  Raters the user to modify the count of events or the value of tokens based on the time. Scripts allow the user the extend Gogen's logic through simple [Lua](http://lua.org/) scripts. Lets see this in action.
+Two of the most important concepts in Gogen are the concepts of rater and scripts.  Raters allow the user to modify the count of events or the value of tokens based on the time. Scripts allow the user the extend Gogen's logic through simple [Lua](http://lua.org/) scripts. Lets see this in action.
 
     raters:
       - name: eventrater
@@ -63,7 +63,7 @@ Two of the most important concepts in Gogen are the concepts of rater and script
             return options["multiplier"]
         options:
             multiplier: 2
-    
+
     samples:
       - name: tutorial2
         begin: 2012-02-09T08:00:00Z
@@ -74,7 +74,7 @@ Two of the most important concepts in Gogen are the concepts of rater and script
 
         tokens:
           - name: ts
-            format: template                                         
+            format: template
             type: timestamp
             replacement: "%b/%d/%y %H:%M:%S"
           - name: linenum
@@ -104,17 +104,17 @@ Two of the most important concepts in Gogen are the concepts of rater and script
 
 Go ahead and run this.
 
-    gogen -c examples/tutorial/tutorial1.yml
+    gogen -c examples/tutorial/tutorial2.yml
 
 Let's examine this config in detail, because it introduces a number of important concepts.  First, this config, rather than running over a specified number of intervals, is setup to run over a specific time period by setting the `begin` and `end` clauses of the sample.  It is set to generate `count: 2` events, once per minute, with an `interval` of `60`.  Lastly, it sets a rater of `eventrater`, which we will explain in detail.
 
-There are two types of raters, `config` and `script`.  The last, `default`, always returns 1.  Raters return a value to _multiply_ events by.  If an event has a count of 2, it'll be multiplied by the value returned by the `eventrater` rater.  The `config` rater will rate events by the time of the event.  In this case, the event will always be between 8 AM and 8:03 AM, so we've only set a few `MinuteOfHour` options, but canonically [it will look more like this](tests/rater/configrater.yml).  The `config` rater has three options, `MinuteOfHour`, `HourOfDay` and `DayOfWeek`.  It will look up the current time of the event in each of these three options, and if found, multiply the `count` (set by `count` in the event) by this floating point value, and once all the multiplications are done, round to the nearest whole number.
+There are two types of raters, `config` and `script`.  The last, `default`, always returns 1.  Raters return a value to _multiply_ events by.  If an event has a count of 2, it'll be multiplied by the value returned by the `eventrater` rater.  The `config` rater will rate events by the time of the event.  In this case, the event will always be between 8 AM and 8:03 AM, so we've only set a few `MinuteOfHour` options, but canonically [it will look more like this](../tests/rater/configrater.yml).  The `config` rater has three options, `MinuteOfHour`, `HourOfDay` and `DayOfWeek`.  It will look up the current time of the event in each of these three options, and if found, multiply the `count` (set by `count` in the event) by this floating point value, and once all the multiplications are done, round to the nearest whole number.
 
-In our example, we should see 2 events generated in the first minute, 1 event in the second minute, and 4 events in the last minute.  
+In our example, we should see 2 events generated in the first minute, 1 event in the second minute, and 4 events in the last minute.
 
-Now, lets look at the tokens for this sample.  The first token introduces a custom script token.  This script is written in [Lua](http://lua.org/), which is very [easy to learn](https://www.lua.org/pil/1.html).  Most people who are versed in scripting or programming can pick up Lua merely by modifying the examples provided with Gogen.  The `linenum` token is very simple, as all it does is return a monotonically increasing identifier to be used as our line number.  Useful, but simple.  It's initialized with the `init` configuration directive, to create an entry in the `state` table in Lua under the `id` item, and set it to zero.  The script increments this id and returns the value on every iteration.
+Now, lets look at the tokens for this sample.  The second token introduces a custom script token.  This script is written in [Lua](http://lua.org/), which is very [easy to learn](https://www.lua.org/pil/1.html).  Most people who are versed in scripting or programming can pick up Lua merely by modifying the examples provided with Gogen.  The `linenum` token is very simple, as all it does is return a monotonically increasing identifier to be used as our line number.  Useful, but simple.  It's initialized with the `init` configuration directive, to create an entry in the `state` table in Lua under the `id` item, and set it to zero.  The script increments this id and returns the value on every iteration.
 
-The other two tokens show the difference between a random token and a rated token.  Both are configured nearly identically.  `val` and `rated` both have a `replacement` of int, a `lower` and `upper` configuration directive dictating the value ranges to be generated.  The difference is `rated` is run through a rater first, the same way event counts are, by multiplying the random value from the token times the value returned by the rater.  In this case, the rater is a simple script, which looks up a value configured in `options` in the YAML and returns that value as the multiplier.
+The next two tokens show the difference between a random token and a rated token.  Both are configured nearly identically.  `val` and `rated` both have a `replacement` of int, a `lower` and `upper` configuration directive dictating the value ranges to be generated.  The difference is `rated` is run through a rater first, the same way event counts are, by multiplying the random value from the token times the value returned by the rater.  In this case, the rater is a simple script, which looks up a value configured in `options` in the YAML and returns that value as the multiplier.
 
 This example is much more complicated than the original, but begins to show off the true power of what Gogen can do with easy to understand and share configurations.
 
@@ -124,7 +124,7 @@ Gogen was enhanced to include the easy addition of custom scripts to enhance the
 
 Tokens have two different `format` options, `regex` and `template`.  `regex` will search a line for a regex pattern and replace any matches with the value from the token.  `template` is *far* preferred and *significantly more performant*, and it will replace, by default, a token matching `$<name>$` in the original event.  Template is intended if you're manually crafting an event, no need to waste the CPU cycles to do regex matches when a simple string match will do.  If you have a token named `foo`, it will search for the text `$foo$` in the original event and replace that.
 
-Tokens also have a number of `type` settings.  See the [Reference manual](README/Reference.md) for a full list, but the primary categories are `timestamp`, `static`, `random`, `rated`, `choice` (with `fieldChoice` and `weightedChoice`) and `script`.  Most important are the `choice` settings, and thusly the section about sample files.  Choice settings can be determined by bringing in data from external files.  Lets examine tutorial 3 in more detail for some examples:
+Tokens also have a number of `type` settings.  See the [Reference manual](Reference.md) for a full list, but the primary categories are `timestamp`, `static`, `random`, `rated`, `choice` (with `fieldChoice` and `weightedChoice`) and `script`.  Most important are the `choice` settings, and thusly the section about sample files.  Choice settings can be determined by bringing in data from external files.  Lets examine tutorial 3 in more detail for some examples:
 
     name: tutorial3
     begin: 2012-02-09T08:00:00Z
@@ -172,14 +172,14 @@ Tokens also have a number of `type` settings.  See the [Reference manual](README
         format: template
         type: choice
         sample: usernames.sample
-      - name: markets-city 
+      - name: markets-city
         format: template
         token: $city$
         type: fieldChoice
         sample: markets.csv
         srcField: city
         group: 1
-      - name: markets-state 
+      - name: markets-state
         format: template
         token: $state$
         type: fieldChoice
@@ -221,15 +221,15 @@ Now, let's look through the tokens to better understand a more complicated token
 
 Next is the `host` token.  This introduces two new options, the first is a type of `choice`.  `choice` tokens choose from a list of items to get the value from which to substitute.  In this case, we've articulated the values right in the configuration, but `choice`, `fieldChoice` and `weightedChoice` tokens can also get their values from external sample files in flat text file or csv format, which you can see in the `username` token further down.  Lastly, it's important to note the `field` directive, which substitutes `host` into the `host` field of the sample line.  Field can be declared on any token to tell it to replace items in any field in the event, with the default being to replace in `_raw`.
 
-The next token we want to look at is `transtype`.  `transtype` is of type `weightedChoice`, which chooses tokens based on a weighting algorithm.  A token of weight `5` will be 5 times more likely to be chosen than a token of weight `1`.  This is very helpful when trying to model data that looks more like real world data, which isn't necessarily going to have an even distribution.  
+The next token we want to look at is `transtype`.  `transtype` is of type `weightedChoice`, which chooses tokens based on a weighting algorithm.  A token of weight `5` will be 5 times more likely to be chosen than a token of weight `1`.  This is very helpful when trying to model data that looks more like real world data, which isn't necessarily going to have an even distribution.
 
-Next, lets take a look at a series of tokens, the ones prefixed with markets.  These tokens introduce a new type, `fieldChoice`, and a few new directives, `srcField` and `group`.  `fieldChoice` tokens will select a replacement from a field from a tablular dataset, like a CSV or a list of YAML objects.  What makes these even more useful, is that the choice we make can be carried across multiple token substitutions.  This is what the `group` clause is for, and it can be used in any of the choice token types.  Any time a `group` clause is present, the same choice will be used across any matched group number.  
+Next, lets take a look at a series of tokens, the ones prefixed with markets.  These tokens introduce a new type, `fieldChoice`, and a few new directives, `srcField` and `group`.  `fieldChoice` tokens will select a replacement from a field from a tablular dataset, like a CSV or a list of YAML objects.  What makes these even more useful, is that the choice we make can be carried across multiple token substitutions.  This is what the `group` clause is for, and it can be used in any of the choice token types.  Any time a `group` clause is present, the same choice will be used across any matched group number.
 
 ## Generators & Templates
 
 As I was rewriting the original Eventgen concept that was to become Gogen, I really wanted to preserve Eventgen's ability to be expandable.  Eventgen allows users to ship custom generators in their Eventgens, so I wanted to replicate that in Gogen.  However, unlike python which is a dynamic, interpreted language, Gogen is written in Go which is a strongly typed, compiled & statically linked language.  In order to give that capability, we do that through custom Lua generators, which have a rich API to allow the Lua scripts to interact with Gogen.  This allows for higher performance, as most of the work is handled in Go code, and it allows for the script developer to minimize the amount of things they need to replicate in their own code.
 
-Secondly, I wanted the ability to customize how we output data.  Making that format expandable will future proof Gogen, and allow field expandability to model new types of data formats.  Gogen can output raw text, JSON, CSV and other formats by default, but custom templates allow for more complicated data structures.
+Secondly, I wanted the ability to customize how we output data.  Making that format expandable will future proof Gogen and allow field expandability to model new types of data formats.  Gogen can output raw text, JSON, CSV and other formats by default, but custom templates allow for more complicated data structures.
 
 For the next example, we're going to show both of these features generating an ini-style configuration file just for giggles.
 
@@ -272,7 +272,7 @@ For the next example, we're going to show both of these features generating an i
       tokens:
         - name: ts
           field: header
-          format: template                                         
+          format: template
           type: timestamp
           replacement: "%b/%d/%y %H:%M:%S"
 
@@ -290,7 +290,7 @@ For the next example, we're going to show both of these features generating an i
       row: |
         [{{ .index }}]
         homePath = {{ .homePath }}
-        coldPath = {{ .coldPath }} 
+        coldPath = {{ .coldPath }}
         thawedPath = {{ .thawedPath }}
         {{ if .maxDataSize -}}
         maxDataSize = {{ .maxDataSize }}
@@ -303,7 +303,7 @@ Let's go ahead and run this to get a look at the output:
 
     gogen -c examples/tutorial/tutorial4.yml
 
-As you can see, it does indeed look like an ini file configuration.  It's modeled after Splunk's indexes.conf.  Once again, we're introducing several important new concepts.  The first, is our `global` section, which we described earlier but it's the first time we've seen it.  Here, global sets the outputTemplate which we're defining below.  
+As you can see, it does indeed look like an ini file configuration.  It's modeled after Splunk's indexes.conf.  Once again, we're introducing several important new concepts.  The first, is our `global` section, which we described earlier but it's the first time we've seen it.  Here, global sets the outputTemplate which we're defining below.
 
 Next, let's look at the `generator` stanza.  This aligns also with the `generator` directive in the sample stanza.  We define here one generator, named indexes.conf, and we're using the `script` directive to define the script inline in the yaml, but we optionally could have pointed to a file with the `fileName` directive.  This defines a relatively simple lua script, which we'll walk through in more detail.
 
@@ -319,7 +319,7 @@ Now, let's look at the templates section.  We define here a new template, called
 
 Sometimes you just want to walk through a set of data as it was originally created.  Maybe you've found a log file that you just want to replay like it's happening right now, or you have some data in another system that is already structured and you want to be able to walk through it.  In this example, I've exported a search from Splunk's \_internal logs and I'm going to replay them like it's right now.
 
-    samples:  
+    samples:
     - name: tutorial5
       generator: replay
 
@@ -339,7 +339,7 @@ Note, it will continue to just run.  Hit `^C` to exit Gogen.  This example pulls
 
 ## Mixes
 
-Much of what users of Gogen need to do is to assemble a realistic set of data to test their use case.  This is why we built the [config sharing system](README/Sharing.md).  What if someone has already published something and you want to combine it with your own or another configuration?  This is what we created mixes for.
+Much of what users of Gogen need to do is to assemble a realistic set of data to test their use case.  This is why we built the [config sharing system](Sharing.md).  What if someone has already published something and you want to combine it with your own or another configuration?  This is what we created mixes for.
 
     mix:
       - sample: $GOGEN_HOME/examples/tutorial/tutorial1.yml
@@ -364,13 +364,13 @@ You'll see they generate in real time.  End generation with another `^C`.
 
 ## Config Done!
 
-You're now a functional expert, assuming you've read this far, in Gogen configuration.  Make sure to check out [more examples](README/Examples.md) where we list a number of examples developed by [myself](http://github.com/coccyx) and the community.
+You're now a functional expert, assuming you've read this far, in Gogen configuration.  Make sure to check out [more examples](Examples.md) where we list a number of examples developed by [myself](http://github.com/coccyx) and the community.
 
 # Using Gogen
 
 Gogen also has a number of features to learn for using it day to day.  Gogen has a number of options which will change its behavior.  Let's look at the weblog example for some different usage patterns.
 
-    gogen -c examples/weblog/weblog.yml 
+    gogen -c examples/weblog/weblog.yml
 
 This will output 10 events.  Let's output 10 events but over 10 seconds, one event per second, instead of all with the same timestamp.  Setting `--endIntervals` or `-ei` will automatically set the beginning time back the number of intervals specified.  Setting `--count` or `-c` will set the count to the specified number per interval.
 
@@ -402,7 +402,7 @@ We may want to use Gogen for performance testing.  In order to do this, we're pr
 
 We may want Gogen to generate static data, where outputting to a file would make sense.  To output a CSV file for example, use `--output` and `--outputTemplate` together.
 
-    gogen -c examples/csv/csv.yml -o file -f test.csv 
+    gogen -c examples/csv/csv.yml -o file -f test.csv
 
 Gogen provides a configuration sharing service which allows for easy sharing of examples.  Let's see if someone has a weblog available through the service.
 


### PR DESCRIPTION
Fixed:

- Some unneeded whitespace
- Broken links
- Unclear/wrong wording